### PR TITLE
Support for observers (wrapping render functions to make them autoruns).

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Reactive variable and autorun library in 20 lines of code -- inspired by Meteor.
 
 Munchlax gives you reactive variables, computed variables and autoruns:
 
-```javascript
+```jsx
 
-const { val, comp } = require("atlas-munchlax");
+const { val, comp, obs } = require("atlas-munchlax");
 
 // reactive variables with initial values
 const firstName = val("Atlas");
@@ -44,13 +44,24 @@ comp(() => {
   })
 })
 
+// reactively "observe" render functions (like in Mobx)
+// shares all the same properties as reactive computations
+//   * scoped reactivity, no redundant renders, etc.
+const App = obs(() => {
+  // automatically rerenders when firstName is set
+  return (
+    <div>
+      My name is {firstName()}
+    </div>
+  )
+})
 ```
 
 > If you read the source code, you might notice that this library is (relatively) trivial compared to MobX or Meteor.Tracker. That's because [Relax](https://github.com/atlassubbed/atlas-relax) is doing *all* of the heavy lifting -- we've reduced the task of state management to [*picking a pattern*](#another-pattern) we'd like to use! All of these patterns can be implemented on top of Relax's lego-like primitives. The key here is that the same engine for VDOM/graph diffing and reconcilation can easily power both UI frameworks and state management frameworks.
 
 ### concepts
 
-Everything in Munchlax is either a **reactive variable** or a **reactive computation** (an "observed" function). If a reactive computation returns a value, then that value is a "derived" value, and can be depended on by other reactive computations as if it were a reactive variable. Reactive computations are just functions which track (i.e. "observe") the values they depend on. If an underlying value changes, the computation is rerun efficiently and atomically.
+Everything in Munchlax is either a **reactive variable** or a **reactive computation** (an "observed" function). If a reactive computation returns a value, then that value is a "derived" value, and can be depended on by other reactive computations as if it were a reactive variable. Reactive computations are just functions which track ("observe") the values they depend on. If an underlying value changes, the computation is rerun efficiently and atomically.
 
 ### getting/setting reactive variables in other frameworks
 
@@ -77,38 +88,37 @@ npm install --save atlas-relax # peer dependency
 npm install --save atlas-munchlax
 ```
 
-### another pattern!
+### `obs` vs. `comp`
 
-Munchlax exports `val` and `comp`, which are helpers for using the reactive variable/autorun pattern we saw in frameworks like Meteor and MobX. All it takes is a few lines of code to build your own pattern. Let's implement `observer` from MobX:
+A `comp` is like MobX's `autorun` and `@computed` APIs in one function. It is similar to Meteor's `Tracker.autorun` as well.
+
+`obs` is basically the same as `comp`, except it lets you "wrap" render functions and automatically turn them into reactive autoruns. The `obs` implementation is 4 lines of code. It's so short because it's an API wrapper for something you can already do with Relax. 
+
+Relax is a state management library, but it is not opinionated. It provides the necessary primitives for you to form your own opinion. *Munchlax* is merely an opinion, and it's for the people who love Meteor or MobX. If you aren't one of those people, don't worry -- Relax makes it easy for you to use a different opinion. Hopefully you will feel more at home with `val`, `comp`, and `obs` if you enjoyed Meteor and MobX:
 
 ```jsx
-const obs = render => {
-  return (t, f, d) => {
-    f.deps = f.deps || [], par = f;
-    while(d = f.deps.pop()) f.unsub(d);
-    par = void(t = render(t, f));
-    return t;
-  }
-}
+import { val, obs } from "atlas-munchlax";
+import { t } from "atlas-relax-jsx-pragma";
+/**@jsx t */
 
-// use
-// global reactive state variable ("sideways" data)
+// global "sideways" data
 const isDarkMode = val(false)
+
 // every instance is automatically reactive
-const MyComponent = obs(() => {
-  return (
-    <div>
+const MyDashboard = obs(() => {
+  const toggle = () => isDarkMode(!isDarkMode());
+  return [
+    <p>
       We're currently in {isDarkMode() ? "night" : "day"} mode
-    </div>
-  )
+    </p>,
+    <button onClick={toggle}>
+      Toggle night mode
+    </button>
+  ]
 })
 ```
 
-That was easy, because Relax is doing all of the actual work -- we didn't have to implement any kind of precise update propagation logic because Relax takes care of it all. Instead of importing an entire reactive framework like MobX, we get all the real power of MobX with a single helper function.
-
-Homework: How is this different than `comp`?
-
-<sup>Hint: It's not all that different. The VDOM in Relax isn't a V*DOM*. `comp`s return a list of computations and each `comp` in the list is a child in a `comp` tree (not a DOM!). What children are we returning in `obs`?</sup>
+Instead of importing an entire reactive framework like MobX, we get most of the power of MobX with a 4 line helper function.
 
 #### credits
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const App = obs(() => {
 })
 ```
 
-> If you read the source code, you might notice that this library is (relatively) trivial compared to MobX or Meteor.Tracker. That's because [Relax](https://github.com/atlassubbed/atlas-relax) is doing *all* of the heavy lifting -- we've reduced the task of state management to [*picking a pattern*](#another-pattern) we'd like to use! All of these patterns can be implemented on top of Relax's lego-like primitives. The key here is that the same engine for VDOM/graph diffing and reconcilation can easily power both UI frameworks and state management frameworks.
+> If you read the source code, you might notice that this library is (relatively) trivial compared to MobX or Meteor.Tracker. That's because [Relax](https://github.com/atlassubbed/atlas-relax) is doing *all* of the heavy lifting -- we've reduced the task of state management to [*picking a pattern*](#obs-vs-comp) we'd like to use! All of these patterns can be implemented on top of Relax's lego-like primitives. The key here is that the same engine for VDOM/graph diffing and reconcilation can easily power both UI frameworks and state management frameworks.
 
 ### concepts
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reactive variable and autorun library in 20 lines of code -- inspired by Meteor.
 
 [<img alt="Munchlax being awesome" align="right" width="200" src="https://user-images.githubusercontent.com/38592371/54497007-f192c700-48cb-11e9-99c9-f040209c362d.png">](https://pokemondb.net/pokedex/munchlax?q=use-atlas-relax)
 
-Munchlax gives you reactive variables, computed variables observers, and autoruns:
+Munchlax gives you reactive variables, computed variables, observers, and autoruns:
 
 ```jsx
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reactive variable and autorun library in 20 lines of code -- inspired by Meteor.
 
 [<img alt="Munchlax being awesome" align="right" width="200" src="https://user-images.githubusercontent.com/38592371/54497007-f192c700-48cb-11e9-99c9-f040209c362d.png">](https://pokemondb.net/pokedex/munchlax?q=use-atlas-relax)
 
-Munchlax gives you reactive variables, computed variables and autoruns:
+Munchlax gives you reactive variables, computed variables observers, and autoruns:
 
 ```jsx
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ comp(() => {
 
 // reactively "observe" render functions (like in Mobx)
 // shares all the same properties as reactive computations
+//   * can nest comps and children can be observed, too
 //   * scoped reactivity, no redundant renders, etc.
 const App = obs(() => {
   // automatically rerenders when firstName is set
@@ -66,7 +67,7 @@ Everything in Munchlax is either a **reactive variable** or a **reactive computa
 ### getting/setting reactive variables in other frameworks
 
   1. **Meteor**: Meteor has a very explicit syntax for getting/setting reactive variables. First, you create the variable with `const name = new ReactiveVar("atlas")`, then you can get it with `name.get()` and set it with `name.set("jai")`. This is a bit verbose.
-  2. **MobX**: MobX is on the other end of the spectrum. You initialize instance values with `@observable name = "atlas"`, then you can get them by calling `this.name` and set them with `this.name = "jai"`. This is too implicit and obfuscates reactivity intent.
+  2. **MobX**: MobX is on the other end of the spectrum. You initialize instance values with `@observable name = "atlas"`, then you can get them by calling `this.name` and set them with `this.name = "jai"`. This is too implicit and obfuscates reactivity intent -- there are too many gotchyas for beginners.
   3. **S**: S introduced an API that is half-way between the above two. To create values, you use `const name = S.data("atlas")`, to get them you do `name()` and to set them, you send the variable a new value with `name("jai")`.
 
 Munchlax keeps things explicit and terse by using S's syntax.
@@ -92,9 +93,9 @@ npm install --save atlas-munchlax
 
 A `comp` is like MobX's `autorun` and `@computed` APIs in one function. It is similar to Meteor's `Tracker.autorun` as well.
 
-`obs` is basically the same as `comp`, except it lets you "wrap" render functions and automatically turn them into reactive autoruns. The `obs` implementation is 4 lines of code. It's so short because it's an API wrapper for something you can already do with Relax. 
+`obs` is basically the same as `comp`, except it lets you "wrap" render functions and automatically turn them into reactive autoruns. The `obs` implementation is 6 lines of code. It's so short because it's an API wrapper for something you can already do with Relax. 
 
-Relax is a state management library, but it is not opinionated. It provides the necessary primitives for you to form your own opinion. *Munchlax* is merely an opinion, and it's for the people who love Meteor or MobX. If you aren't one of those people, don't worry -- Relax makes it easy for you to use a different opinion. Hopefully you will feel more at home with `val`, `comp`, and `obs` if you enjoyed Meteor and MobX:
+Relax is a state management library, but it is not opinionated. It provides the necessary primitives for you to form your own opinion. *Munchlax* is merely an opinion, and it's for the people who love Meteor and MobX. If you aren't one of those people, don't worry -- Relax makes it easy for you to use a different opinion. Hopefully you will feel at home with `val`, `comp`, and `obs`:
 
 ```jsx
 import { val, obs } from "atlas-munchlax";
@@ -118,7 +119,7 @@ const MyDashboard = obs(() => {
 })
 ```
 
-Instead of importing an entire reactive framework like MobX, we get most of the power of MobX with a 4 line helper function.
+Instead of importing an entire reactive framework like MobX, we get most of the power of MobX with a 6 line helper function.
 
 #### credits
 

--- a/src/munchlax.js
+++ b/src/munchlax.js
@@ -36,10 +36,12 @@ const comp = (render, cur, self) => {
 
 // reactive observer (essentially turns render into a reactive comp)
 const obs = render => (t, f, d) => {
-  f.deps = f.deps || [], par = f;
+  f.comps = f.comps || [], f.deps = f.deps || [], par = f;
   while(d = f.deps.pop()) f.unsub(d);
-  par = void(t = render(t, f));
-  return t;
+  while(d = f.comps.pop()) diff(null, d);
+  t = render(t, f), d = f.comps.length;
+  while(d--) f.comps[d] = diff(f.comps[d]);
+  return par = null, t;
 }
 
 module.exports = { val, comp, obs };

--- a/src/munchlax.js
+++ b/src/munchlax.js
@@ -34,4 +34,12 @@ const comp = (render, cur, self) => {
   return () => (track(self), cur);
 }
 
-module.exports = { val, comp };
+// reactive observer (essentially turns render into a reactive comp)
+const obs = render => (t, f, d) => {
+  f.deps = f.deps || [], par = f;
+  while(d = f.deps.pop()) f.unsub(d);
+  par = void(t = render(t, f));
+  return t;
+}
+
+module.exports = { val, comp, obs };

--- a/test/munchlax.test.js
+++ b/test/munchlax.test.js
@@ -1,11 +1,13 @@
 const { describe, it } = require("mocha")
 const { expect } = require("chai")
-const { val, comp } = require("../");
+const { val, comp, obs } = require("../");
+const { diff } = require("atlas-relax");
 
 const asap = Promise.resolve().then.bind(Promise.resolve())
+const h = name => ({name});
 
-describe("reactive computations", function(){
-  describe("reactive variable", function(){
+describe("reactivity", function(){
+  describe("reactive variables", function(){
     it("should get variables with no initial value", function(){
       const first = val();
       expect(first()).to.be.undefined;
@@ -24,7 +26,7 @@ describe("reactive computations", function(){
       expect(first()).to.equal("jai")
     })
   })
-  describe("reactive computation", function(){
+  describe("reactive computations", function(){
     it("should get computations with no return value", function(){
       const first = comp(() => {})
       expect(first()).to.be.undefined;
@@ -209,6 +211,239 @@ describe("reactive computations", function(){
       asap().then(() => {
         expect(called).to.equal(2);
         expect(full()).to.equal("jai munchies");
+        done();
+      })
+    })
+  })
+  describe("reactive (observed) render functions", function(){
+    it("should run render with no return value", function(){
+      let called = 0;
+      diff(h(obs(() => {
+        called++;
+      })))
+      expect(called).to.equal(1);
+    })
+    it("should run render that return children", function(){
+      let called = 0, calledChild = 0;
+      diff(h(obs(() => {
+        called++;
+        return h(() => calledChild++)
+      })))
+      expect(called).to.equal(1);
+      expect(calledChild).to.equal(1);
+    })
+    it("should run render that depends on a reactive variable", function(){
+      const first = val("atlas")
+      let called = 0, seenValue;
+      diff(h(obs(() => {
+        called++;
+        seenValue = first();
+      })))
+      expect(called).to.equal(1);
+      expect(seenValue).to.equal("atlas");
+    })
+    it("should rerender when an underlying reactive variable updates", function(){
+      const first = val("atlas")
+      let called = 0, seenValue;
+      diff(h(obs(() => {
+        called++;
+        seenValue = first();
+      })))
+      first("jai")
+      expect(called).to.equal(2);
+      expect(seenValue).to.equal("jai")
+    })
+    it("should not rerender when an underlying reactive variable does not change", function(){
+      const first = val("atlas", (cur, next) => cur !== next)
+      let called = 0, seenValue;
+      diff(h(obs(() => {
+        called++;
+        seenValue = first();
+      })))
+      first("atlas")
+      expect(called).to.equal(1);
+      expect(seenValue).to.equal("atlas")
+    })
+    it("should run render that depends on a derived reactive computation", function(){
+      const first = val("atlas")
+      const last = val("subbed");
+      const full = comp(() => `${first()} ${last()}`)
+      let called = 0, seenValue;
+      diff(h(obs(() => {
+        called++;
+        seenValue = full();
+      })))
+      expect(called).to.equal(1);
+      expect(seenValue).to.equal("atlas subbed");
+    })
+    it("should rerender when an underlying reactive computation updates", function(){
+      const first = val("atlas")
+      const last = val("subbed");
+      const full = comp(() => `${first()} ${last()}`)
+      let called = 0, seenValue;
+      diff(h(obs(() => {
+        called++;
+        seenValue = full();
+      })))
+      first("jai")
+      expect(called).to.equal(2);
+      expect(seenValue).to.equal("jai subbed");
+    })
+    it("should dynamically depend on the most recently accessed reactive variables", function(){
+      const first = val();
+      const last = val("subbed");
+      let called = 0, seenValue;
+      diff(h(obs(() => {
+        called++;
+        seenValue = first() || last();
+      })))
+      expect(called).to.equal(1)
+      expect(seenValue).to.equal("subbed");
+      first("atlas")
+      expect(called).to.equal(2)
+      expect(seenValue).to.equal("atlas");
+      last("munchies")
+      expect(called).to.equal(2)
+      expect(seenValue).to.equal("atlas");
+      first(null);
+      expect(called).to.equal(3)
+      expect(seenValue).to.equal("munchies");
+    })
+    it("should rerender observed children when observed parent updates", function(){
+      const first = val("atlas");
+      const last = val("subbed");
+      let calledOuter = 0, calledInner = 0;
+      diff(h(obs(() => {
+        first(), calledOuter++;
+        return h(obs(() => {
+          last(), calledInner++;
+        }))
+      })))
+      first("jai");
+      expect(calledOuter).to.equal(2);
+      expect(calledInner).to.equal(2)
+    })
+    it("should not rerender observed parents when observed child updates", function(){
+      const first = val("atlas");
+      const last = val("subbed");
+      let calledOuter = 0, calledInner = 0;
+      diff(h(obs(() => {
+        first(), calledOuter++;
+        return h(obs(() => {
+          last(), calledInner++;
+        }))
+      })))
+      last("munchies");
+      expect(calledOuter).to.equal(1);
+      expect(calledInner).to.equal(2)
+    })
+    it("should run renders in top-bottom order", function(){
+      const called = [];
+      diff(h(obs(() => {
+        called.push(1);
+        return [
+          h(obs(() => called.push(2))),
+          h(obs(() => called.push(3))),
+          h(obs(() => called.push(4)))
+        ]
+      })))
+      expect(called).to.eql([1,2,3,4])
+    })
+    it("should re-run computations in top-bottom order", function(){
+      const first = val("atlas")
+      const called = [];
+      diff(h(obs(() => {
+        first(), called.push(1);
+        return [
+          h(obs(() => called.push(2))),
+          h(obs(() => called.push(3))),
+          h(obs(() => called.push(4)))
+        ]
+      })))
+      first("jai")
+      expect(called).to.eql([1,2,3,4,1,2,3,4])
+    })
+    it("should update observed progeny atomically", function(){
+      const first = val("atlas");
+      const called = [];
+      diff(h(obs(() => {
+        first(), called.push(1);
+        return h(obs(() => {
+          first(), called.push(2);
+          return h(obs(() => {
+            first(), called.push(3);
+          }))
+        }))
+      })))
+      first("jai")
+      expect(called).to.eql([1,2,3,1,2,3])
+    })
+    it("should update observed derived computations atomically", function(){
+      const first = val("atlas");
+      const last = val("subbed");
+      const full = comp(() => `${first()} ${last()}`)
+      const initials = comp(() => full().split(" ").map(n => n[0]).join(""))
+      let called = 0;
+      diff(h(obs(() => {
+        first(), full(), initials(), called++;
+      })));
+      first("jai")
+      expect(called).to.equal(2)
+    })
+    it("should dynamically depend on only the currently used observed progeny", function(){
+      const precipitation = val("rain");
+      const isSunny = val(false);
+      let calledInner = 0, calledOuter = 0;
+      diff(h(obs(() => {
+        calledOuter++;
+        return isSunny() || h(obs(() => {
+          calledInner++;
+          precipitation()
+        }))
+      })));
+      expect(calledOuter).to.equal(1)
+      expect(calledInner).to.equal(1)
+      isSunny(true);
+      expect(calledOuter).to.equal(2);
+      expect(calledInner).to.equal(1);
+      precipitation("hail");
+      expect(calledOuter).to.equal(2);
+      expect(calledInner).to.equal(1);
+    })
+    it("should not batch renders due to reactive variable updates by default", function(){
+      const first = val("atlas");
+      const last = val("subbed");
+      let called = 0, seenVal;
+      diff(h(obs(() => {
+        called++;
+        seenVal = `${first()} ${last()}`;
+      })))
+      expect(called).to.equal(1);
+      first("jai")
+      expect(called).to.equal(2);
+      expect(seenVal).to.equal("jai subbed")
+      last("munchies")
+      expect(called).to.equal(3);
+      expect(seenVal).to.equal("jai munchies")
+    })
+    it("should batch renders when reactive variables update if batch function is provided", function(done){
+      const first = val("atlas");
+      const last = val("subbed");
+      let called = 0, seenVal;
+      diff(h(obs(() => {
+        called++;
+        seenVal = `${first()} ${last()}`
+      })))
+      expect(called).to.equal(1);
+      first("jai", asap)
+      expect(called).to.equal(1);
+      expect(seenVal).to.equal("atlas subbed")
+      last("munchies", asap)
+      expect(called).to.equal(1);
+      expect(seenVal).to.equal("atlas subbed");
+      asap().then(() => {
+        expect(called).to.equal(2);
+        expect(seenVal).to.equal("jai munchies");
         done();
       })
     })


### PR DESCRIPTION
You should be able to do whatever you need to do with `comp`, but it can be a bit verbose. So, I implemented `obs` which lets you do things cleanly and minimally like you would in MobX:

```javascript
// global-reactive-variables.js
import { val } from "atlas-munchlax";
export const nightMode = val(false);
```
```jsx
// ThemeWrapper.js
import { obs } from "atlas-munchlax";
import { nightMode } from "./global-reactive-variables";
export const ThemeWrapper = obs(({next}) => (
  // automatically rerenders when some other part of your app
  // toggles nightmode
  <div class={nightMode() ? "dark" : "light"}>
    {next}
  </div>
))
```

# *it just works*
![todd](https://media1.tenor.com/images/b66b02c7af4f61cf24b0416e87bc3c0f/tenor.gif?itemid=13246550)